### PR TITLE
feat: add provider Launch, by Adobe (#313)

### DIFF
--- a/src/lib/providers/launch/README.md
+++ b/src/lib/providers/launch/README.md
@@ -1,0 +1,57 @@
+<img 
+    src="https://developer.adobelaunch.com/images/launch.svg" 
+    alt="Launch, by Adobe logo"
+    height="100px"
+    width="100px" />
+
+# Launch, by Adobe
+__homepage__: [Launch, by Adobe](https://www.adobe.com/experience-platform/launch.html)  
+__docs__: [developer.adobelaunch.com/](https://developer.adobelaunch.com/)  
+__import__: `import { Angulartics2LaunchByAdobe } from 'angulartics2/launch';`  
+
+
+## Initial Setup
+
+Add your Launch embed code to the end of your head tag, as usual.
+
+You can either add just the embed code with "async", or non-async embed code in the head plus the <code>_satellite.pageBottom()</code> snippet at the end of the body.
+
+## Include it in your application
+
+Bootstrapping the application with ```Angulartics2``` as provider and injecting both ```Angulartics2``` and ```Angulartics2LaunchByAdobe``` (or any provider) into the root component will hook into the router and send every route change to Launch, where it can be used for Analytics tracking or a lot of other things.
+
+
+```ts
+// component
+import { Angulartics2LaunchByAdobe } from 'angulartics2/launch';
+
+@Component({ ... })
+export class AppComponent {
+  // import Angulartics2LaunchByAdobe in root component
+  constructor(angulartics2LaunchByAdobe: Angulartics2LaunchByAdobe) {
+    angulartics2LaunchByAdobe.startTracking();
+  }
+}
+```
+
+```ts
+// bootstrap
+import { Angulartics2Module } from 'angulartics2';
+import { Angulartics2LaunchByAdobe } from 'angulartics2/launch';
+
+@NgModule({
+  imports: [
+    ...
+    // import Angulartics2LaunchByAdobe in root ngModule    
+    Angulartics2Module.forRoot([ Angulartics2LaunchByAdobe ])
+  ],
+})
+```
+
+## Setting Up Tags
+
+Once set up, Angulartics [usage](https://github.com/angulartics/angulartics2#usage) is the same regardless of provider
+
+Now is the time to setup tracking in Launch.  [Here is a post](http://webanalyticsfordevelopers.com/2018/11/06/basic-tracking-remix-contains-launch/) explaining how a basic tracking setup can be done.
+
+_For detailed instructions on how to send tracking events in a component or in a template check out the documentation for [Tracking Events](https://github.com/angulartics/angulartics2/wiki/Tracking-Events)._

--- a/src/lib/providers/launch/launch.spec.ts
+++ b/src/lib/providers/launch/launch.spec.ts
@@ -1,0 +1,61 @@
+import { fakeAsync, inject, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { Angulartics2 } from 'angulartics2';
+import { advance, createRoot, RootCmp, TestModule } from '../../test.mocks';
+import { Angulartics2LaunchByAdobe } from './launch';
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;
+declare var window: any;
+
+describe('Angulartics2LaunchByAdobe', () => {
+  let _satellite: any;
+  let fixture: ComponentFixture<any>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TestModule],
+      providers: [Angulartics2LaunchByAdobe],
+    });
+
+    window._satellite = _satellite = {};
+    _satellite.track = function(eventID: String, payload: any) {
+      _satellite.output = {
+        'eventID' : eventID,
+        'payload': payload
+      };
+    };
+    _satellite.output = null;
+    const provider: Angulartics2LaunchByAdobe = TestBed.get(Angulartics2LaunchByAdobe);
+    provider.startTracking();
+  });
+
+  it('should track pages',
+    fakeAsync(inject([Angulartics2, Angulartics2LaunchByAdobe],
+      (angulartics2: Angulartics2) => {
+        fixture = createRoot(RootCmp);
+        angulartics2.pageTrack.next({ path: '/abc' });
+        advance(fixture);
+        expect(Object.keys(_satellite.output)).toEqual(['eventID', 'payload']);
+        expect(_satellite.output.eventID).toEqual('pageTrack');
+        expect(_satellite.output.payload).toEqual('/abc');
+      }
+    )),
+  );
+
+  it('should track events',
+    fakeAsync(inject([Angulartics2, Angulartics2LaunchByAdobe],
+      (angulartics2: Angulartics2) => {
+        fixture = createRoot(RootCmp);
+        angulartics2.eventTrack.next({ action: 'do', properties: { category: 'cat' } });
+        advance(fixture);
+        expect(Object.keys(_satellite.output)).toEqual(['eventID', 'payload']);
+        expect(_satellite.output.eventID).toEqual('eventTrack');
+        expect(Object.keys(_satellite.output.payload)).toEqual(['action', 'eventProperties']);
+        expect(_satellite.output.payload.action).toEqual('do');
+        expect(Object.keys(_satellite.output.payload.eventProperties)).toEqual(['category']);
+        expect(_satellite.output.payload.eventProperties.category).toEqual('cat');
+      }
+    )),
+  );
+
+});

--- a/src/lib/providers/launch/launch.ts
+++ b/src/lib/providers/launch/launch.ts
@@ -1,0 +1,64 @@
+import { Injectable } from '@angular/core';
+
+import { Angulartics2 } from 'angulartics2';
+
+declare const _satellite: any;
+
+@Injectable({ providedIn: 'root' })
+export class Angulartics2LaunchByAdobe {
+  payload: any = {};
+  constructor(
+    protected angulartics2: Angulartics2,
+  ) {
+    if ('undefined' === typeof _satellite) {
+      console.warn('Launch not found!');
+    }
+    this.angulartics2.setUsername
+      .subscribe((x: string) => this.setUsername(x));
+    this.angulartics2.setUserProperties
+      .subscribe((x) => this.setUserProperties(x));
+  }
+
+  setUsername(userId: string | boolean) {
+    if ('undefined' !== typeof userId && userId) {
+      this.payload.userId = userId;
+    }
+  }
+
+  setUserProperties(properties: any) {
+    if ('undefined' !== typeof properties && properties) {
+      this.payload.properties = properties;
+    }
+  }
+
+  startTracking() {
+    this.angulartics2.pageTrack
+      .pipe(this.angulartics2.filterDeveloperMode())
+      .subscribe((x) => this.pageTrack(x.path));
+    this.angulartics2.eventTrack
+      .pipe(this.angulartics2.filterDeveloperMode())
+      .subscribe((x) => this.eventTrack(x.action, x.properties));
+  }
+
+  pageTrack(path: string) {
+    if ('undefined' !== typeof _satellite && _satellite) {
+      _satellite.track('pageTrack', path);
+    }
+  }
+
+  /**
+   * @param action associated with the event
+   * @param properties associated with the event
+   */
+  eventTrack(action: string, properties: any) {
+    properties = properties || {};
+
+    // add properties to payload
+    this.payload.action = action;
+    this.payload.eventProperties = properties;
+
+    if ('undefined' !== typeof _satellite && _satellite) {
+      _satellite.track('eventTrack', this.payload);
+    }
+  }
+}

--- a/src/lib/providers/launch/package.json
+++ b/src/lib/providers/launch/package.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../../../../node_modules/ng-packagr/package.schema.json",
+  "name": "angulartics2/launch",
+  "description": "The Launch module",
+  "homepage": "https://angulartics.github.io/angulartics2/",
+  "author": "Jan Exner <jan.exner@gmx.net> (https://github.com/janexner)",
+  "repository": "angulartics/angulartics2",
+  "license": "MIT",
+  "ngPackage": {
+    "lib": {
+      "entryFile": "launch.ts",
+      "umdModuleIds": {
+        "angulartics2": "angulartics2"
+      }
+    },
+    "dest": "../../../../dist/packages-dist/launch"
+  }
+}


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
Added a provider for the recent Tag Managemener Launch, by Adobe

- **What is the current behavior? Link to open issue?**
No provider available for Launch, by Adobe

- **What is the new behavior?**
Provider for Launch, by Adobe, can handle pageTrack and eventTrack.

- **What kind of change does this PR introduce?**


- **What is the current behavior? Link to open issue?**


- **What is the new behavior?**
