### PR TITLE
Properties in launch

### DIFF
--- a/src/lib/providers/launch/launch.spec.ts
+++ b/src/lib/providers/launch/launch.spec.ts
@@ -37,7 +37,8 @@ describe('Angulartics2LaunchByAdobe', () => {
         advance(fixture);
         expect(Object.keys(_satellite.output)).toEqual(['eventID', 'payload']);
         expect(_satellite.output.eventID).toEqual('pageTrack');
-        expect(_satellite.output.payload).toEqual('/abc');
+        expect(Object.keys(_satellite.output.payload)).toEqual(['path']);
+        expect(_satellite.output.payload.path).toEqual('/abc');
       }
     )),
   );

--- a/src/lib/providers/launch/launch.spec.ts
+++ b/src/lib/providers/launch/launch.spec.ts
@@ -16,47 +16,71 @@ describe('Angulartics2LaunchByAdobe', () => {
       imports: [TestModule],
       providers: [Angulartics2LaunchByAdobe],
     });
-
-    window._satellite = _satellite = {};
-    _satellite.track = function(eventID: String, payload: any) {
-      _satellite.output = {
-        'eventID' : eventID,
-        'payload': payload
-      };
-    };
-    _satellite.output = null;
-    const provider: Angulartics2LaunchByAdobe = TestBed.get(Angulartics2LaunchByAdobe);
-    provider.startTracking();
+    window.console = jasmine.createSpyObj('console', ['warn', 'log']);
   });
 
-  it('should track pages',
-    fakeAsync(inject([Angulartics2, Angulartics2LaunchByAdobe],
-      (angulartics2: Angulartics2) => {
-        fixture = createRoot(RootCmp);
-        angulartics2.pageTrack.next({ path: '/abc' });
-        advance(fixture);
-        expect(Object.keys(_satellite.output)).toEqual(['eventID', 'payload']);
-        expect(_satellite.output.eventID).toEqual('pageTrack');
-        expect(Object.keys(_satellite.output.payload)).toEqual(['path']);
-        expect(_satellite.output.payload.path).toEqual('/abc');
-      }
-    )),
-  );
+  describe('on init', () => {
+    beforeEach(() => {
+      window.console = jasmine.createSpyObj('console', ['warn', 'log']);
+      window._satellite = undefined;
+    });
 
-  it('should track events',
-    fakeAsync(inject([Angulartics2, Angulartics2LaunchByAdobe],
-      (angulartics2: Angulartics2) => {
-        fixture = createRoot(RootCmp);
-        angulartics2.eventTrack.next({ action: 'do', properties: { category: 'cat' } });
-        advance(fixture);
-        expect(Object.keys(_satellite.output)).toEqual(['eventID', 'payload']);
-        expect(_satellite.output.eventID).toEqual('eventTrack');
-        expect(Object.keys(_satellite.output.payload)).toEqual(['action', 'eventProperties']);
-        expect(_satellite.output.payload.action).toEqual('do');
-        expect(Object.keys(_satellite.output.payload.eventProperties)).toEqual(['category']);
-        expect(_satellite.output.payload.eventProperties.category).toEqual('cat');
-      }
-    )),
-  );
+    it('should complain if Launch is not found',
+      fakeAsync(inject([Angulartics2LaunchByAdobe],
+        (angulartics2Launch: Angulartics2LaunchByAdobe) => {
+          angulartics2Launch.startTracking();
+          fixture = createRoot(RootCmp);
+          advance(fixture);
+          expect(console.warn).toHaveBeenCalled();
+        }),
+      ),
+    );
+  });
+
+  describe('while active', () => {
+    beforeEach(() => {
+      window._satellite = _satellite = {};
+      _satellite.track = function(eventID: String, payload: any) {
+        _satellite.output = {
+          'eventID' : eventID,
+          'payload': payload
+        };
+      };
+      _satellite.output = null;
+      const provider: Angulartics2LaunchByAdobe = TestBed.get(Angulartics2LaunchByAdobe);
+      provider.startTracking();
+    });
+
+    it('should track pages',
+      fakeAsync(inject([Angulartics2, Angulartics2LaunchByAdobe],
+        (angulartics2: Angulartics2) => {
+          fixture = createRoot(RootCmp);
+          angulartics2.pageTrack.next({ path: '/abc' });
+          advance(fixture);
+          expect(Object.keys(_satellite.output)).toEqual(['eventID', 'payload']);
+          expect(_satellite.output.eventID).toEqual('pageTrack');
+          expect(Object.keys(_satellite.output.payload)).toEqual(['path']);
+          expect(_satellite.output.payload.path).toEqual('/abc');
+        }
+      )),
+    );
+
+    it('should track events',
+      fakeAsync(inject([Angulartics2, Angulartics2LaunchByAdobe],
+        (angulartics2: Angulartics2) => {
+          fixture = createRoot(RootCmp);
+          angulartics2.eventTrack.next({ action: 'do', properties: { category: 'cat' } });
+          advance(fixture);
+          expect(Object.keys(_satellite.output)).toEqual(['eventID', 'payload']);
+          expect(_satellite.output.eventID).toEqual('eventTrack');
+          expect(Object.keys(_satellite.output.payload)).toEqual(['action', 'eventProperties']);
+          expect(_satellite.output.payload.action).toEqual('do');
+          expect(Object.keys(_satellite.output.payload.eventProperties)).toEqual(['category']);
+          expect(_satellite.output.payload.eventProperties.category).toEqual('cat');
+        }
+      )),
+    );
+
+  });
 
 });

--- a/src/lib/providers/launch/launch.ts
+++ b/src/lib/providers/launch/launch.ts
@@ -41,8 +41,11 @@ export class Angulartics2LaunchByAdobe {
   }
 
   pageTrack(path: string) {
+    this.payload = this.payload || {};
+    this.payload.path = path;
+
     if ('undefined' !== typeof _satellite && _satellite) {
-      _satellite.track('pageTrack', path);
+      _satellite.track('pageTrack', this.payload);
     }
   }
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
'properties' are now sent to Launch on pageTrack, not only eventTrack

- **What is the current behavior? Link to open issue?**
Currently, pageTrack only sends the path into Launch

- **What is the new behavior?**
The path is added to the properties, and all properties are sent